### PR TITLE
Fix TLS and export location with Packer

### DIFF
--- a/Vagrant/scripts/install_choco.ps1
+++ b/Vagrant/scripts/install_choco.ps1
@@ -1,4 +1,6 @@
 # Purpose: Install chocolatey to install various windows packages
+# Using TLS1.2
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 Write-Host "$('[{0:HH:mm}]' -f (Get-Date)) Installing Chocolatey"
 $chocoInstall = "C:\ProgramData\chocolatey"

--- a/build.sh
+++ b/build.sh
@@ -176,6 +176,8 @@ prereq_checks() {
 
 # Builds a box using Packer
 packer_build_box() {
+  # Export the box in $DL_DIR default is /tmp
+  export TMP_DIR=$DL_DIR
   BOX="$1"
   cd "$DL_DIR/Packer" || exit 1
   (echo >&2 "Using Packer to build the $BOX Box. This can take 90-180 minutes depending on bandwidth and hardware.")


### PR DESCRIPTION
-Fix TLS issue when installing Choco in the sandbox.  #4 
-Export the box in the DL_DIR to avoid space disk issue